### PR TITLE
Fix player token bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Any important notes regarding the update.
 - Allow to search playlist entries, player errors, users, and song tags.
 - Allow to search songs, playlist entries, player errors and users by ID.
 
+### Fixed
+
+- Fixed a bug when creating a player token with a MariaDB database.
+
 ## 1.9.2 - 2025-03-22
 
 ## 1.9.1 - 2025-03-15

--- a/dakara_server/playlist/serializers.py
+++ b/dakara_server/playlist/serializers.py
@@ -300,11 +300,18 @@ class KaraokeSerializer(serializers.ModelSerializer):
 
 
 class PlayerTokenSerializer(serializers.ModelSerializer):
-    karaoke_id = serializers.PrimaryKeyRelatedField(read_only=True)
+    # get related karaoke field
+    karaoke = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
+
+    # set related karaoke field
+    karaoke_id = serializers.PrimaryKeyRelatedField(
+        write_only=True, source="karaoke", queryset=Karaoke.objects.all()
+    )
 
     class Meta:
         model = PlayerToken
         fields = (
+            "karaoke",
             "karaoke_id",
             "key",
         )

--- a/dakara_server/playlist/tests/test_player_token.py
+++ b/dakara_server/playlist/tests/test_player_token.py
@@ -23,7 +23,7 @@ class PlayerTokenListViewTestCase(PlaylistAPITestCase):
         self.authenticate(self.manager)
 
         # create the token
-        response = self.client.post(self.url, {"karaoke": karaoke.id})
+        response = self.client.post(self.url, {"karaoke_id": karaoke.id})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # check the token exists
@@ -56,7 +56,7 @@ class PlayerTokenViewTestCase(PlaylistAPITestCase):
         self.assertEqual(len(response.data["key"]), 40)
         self.assertEqual(response.data["key"], player_token.key)
 
-        self.assertEqual(response.data["karaoke_id"], player_token.karaoke.id)
+        self.assertEqual(response.data["karaoke"], player_token.karaoke.id)
 
     def test_get_not_found(self):
         """Test to get a token that doesn't exist"""


### PR DESCRIPTION
The problem was due to a misuse of the `karaoke` field in `PlayerTokenSerializer`.

The bug was impossible to reproduce when a SQLite database is used. No new tests were added, but current tests had to be modified.