### PR TITLE
Fix search using remaing terms

### DIFF
--- a/dakara_server/internal/query.py
+++ b/dakara_server/internal/query.py
@@ -29,7 +29,7 @@ def gather_query(query_set, query_list):
     Returns:
         New firtered query set.
     """
-    # now, gather the query objects
+    # now, gather the conjunction of the query objects
     filter_query = Q()
     for item in query_list:
         filter_query &= item
@@ -49,7 +49,7 @@ def gather_query_remain(query_set, query_list_remain):
     Returns:
         New firtered query set.
     """
-    # now, gather the query objects
+    # now, gather the disjunction of the query objects
     filter_query = Q()
     for item in query_list_remain:
         filter_query |= item

--- a/dakara_server/library/query.py
+++ b/dakara_server/library/query.py
@@ -155,8 +155,12 @@ def query_artists(query_set, query):
 
     query_list_remain = []
     # only unspecific terms are used
+    # conjunction of all terms
+    query_remain = Q()
     for remain in res:
-        query_list_remain.append(Q(name__icontains=remain))
+        query_remain &= Q(name__icontains=remain)
+
+    query_list_remain.append(query_remain)
 
     # gather the query objects
     query_set_filtered = gather_query_remain(query_set, query_list_remain)
@@ -180,12 +184,16 @@ def query_works(query_set, query):
 
     query_list_remain = []
     # only unspecific terms are used
+    # conjunction of all terms
+    query_remain = Q()
     for remain in res:
-        query_list_remain.append(
+        query_remain &= (
             Q(title__icontains=remain)
             | Q(subtitle__icontains=remain)
             | Q(alternative_title__title__icontains=remain)
         )
+
+    query_list_remain.append(query_remain)
 
     # gather the query objects
     query_set_filtered = gather_query_remain(query_set, query_list_remain)
@@ -209,8 +217,12 @@ def query_song_tags(query_set, query):
 
     query_list_remain = []
     # only unspecific terms are used
+    # conjunction of all terms
+    query_remain = Q()
     for remain in res:
-        query_list_remain.append(Q(name__icontains=remain))
+        query_remain &= Q(name__icontains=remain)
+
+    query_list_remain.append(query_remain)
 
     # gather the query objects
     query_set_filtered = gather_query_remain(query_set, query_list_remain)

--- a/dakara_server/library/query.py
+++ b/dakara_server/library/query.py
@@ -9,7 +9,7 @@ def make_songs_query_from_res(res, prefix=None):
     """Make a query for songs.
 
     Args:
-        res (dict): Dictionary on research terms, parsed. If `id` is in the
+        res (dict): Dictionary of research terms, parsed. If `id` is in the
             query terms, only filter by it.
         prefix (str or None): Optional prefix to add when creating the query.
 
@@ -85,8 +85,10 @@ def make_songs_query_from_res(res, prefix=None):
         # heavier, for no practical reason
 
     # unspecific terms of the research
+    # conjunction of all terms
+    query_remain = Q()
     for remain in res["remaining"]:
-        query_list_remain.append(
+        query_remain &= (
             q(prefix, "title__icontains", remain)
             | q(prefix, "artists__name__icontains", remain)
             | q(prefix, "works__title__icontains", remain)
@@ -95,6 +97,8 @@ def make_songs_query_from_res(res, prefix=None):
             | q(prefix, "detail__icontains", remain)
             | q(prefix, "detail_video__icontains", remain)
         )
+
+    query_list_remain.append(query_remain)
 
     # tags
     for tag in res["tag"]:

--- a/dakara_server/library/tests/test_artist.py
+++ b/dakara_server/library/tests/test_artist.py
@@ -118,6 +118,11 @@ class ArtistListViewTestCase(LibraryAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
+        # check that only the conjunction of the two words is found (reverse)
+        response = self.client.get(self.url, {"query": "miku hatsune"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
 
 class ArtistPruneViewAPIViewTestCase(LibraryAPITestCase):
     url = reverse("library-artist-prune")

--- a/dakara_server/library/tests/test_artist.py
+++ b/dakara_server/library/tests/test_artist.py
@@ -102,6 +102,22 @@ class ArtistListViewTestCase(LibraryAPITestCase):
             ["word", "words words words", "remain"],
         )
 
+    def test_get_artists_list_with_query_two_words(self):
+        """Test to search the intersection of two words in the query.
+
+        Related to #192.
+        """
+        artist_names = ["hatsune miku", "hatsune", "miku"]
+        for name in artist_names:
+            Artist.objects.create(name=name)
+
+        self.authenticate(self.user)
+
+        # check that only the conjunction of the two words is found
+        response = self.client.get(self.url, {"query": "hatsune miku"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
 
 class ArtistPruneViewAPIViewTestCase(LibraryAPITestCase):
     url = reverse("library-artist-prune")

--- a/dakara_server/library/tests/test_song.py
+++ b/dakara_server/library/tests/test_song.py
@@ -317,6 +317,30 @@ And everywhere that Mary went""",
         self.assertCountEqual(query["work_type"]["wt1"]["contains"], ["workName"])
         self.assertCountEqual(query["work_type"]["wt1"]["exact"], [])
 
+    def test_get_song_list_with_query_two_words(self):
+        """Test to search the intersection of two words in the query.
+
+        Related to #192.
+        """
+        # create songs with "god" and "knows"
+        song_titles = [
+            "she knows",
+            "A Whole New World God Only Knows",
+            "against the gods",
+            "Doggy god's street",
+            "God knows",
+            "God only knows Daisanmaku",
+        ]
+        for title in song_titles:
+            Song.objects.create(title=title)
+
+        self.authenticate(self.user)
+
+        # check that only the conjunction of the two words is found
+        response = self.client.get(self.url, {"query": "god knows"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 3)
+
     def test_get_song_list_disabled_tag(self):
         """Test to verify songs with disabled for user.
 

--- a/dakara_server/library/tests/test_song.py
+++ b/dakara_server/library/tests/test_song.py
@@ -341,6 +341,11 @@ And everywhere that Mary went""",
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 3)
 
+        # check that only the conjunction of the two words is found (reverse)
+        response = self.client.get(self.url, {"query": "knows god"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 3)
+
     def test_get_song_list_disabled_tag(self):
         """Test to verify songs with disabled for user.
 

--- a/dakara_server/library/tests/test_song_tag.py
+++ b/dakara_server/library/tests/test_song_tag.py
@@ -65,6 +65,22 @@ class SongTagListViewTestCase(LibraryAPITestCase):
 
         self.check_query("", [self.tag1, self.tag2])
 
+    def test_get_tag_list_with_query_two_words(self):
+        """Test to search the intersection of two words in the query.
+
+        Related to #192.
+        """
+        tag_names = ["Live performance", "Live", "Performance"]
+        for name in tag_names:
+            SongTag.objects.create(name=name)
+
+        self.authenticate(self.user)
+
+        # check that only the conjunction of the two words is found
+        response = self.client.get(self.url, {"query": "live performance"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     def test_post_tag_already_exists(self):
         """Test to create a tag when it already exists."""
         # Login as simple user

--- a/dakara_server/library/tests/test_song_tag.py
+++ b/dakara_server/library/tests/test_song_tag.py
@@ -81,6 +81,11 @@ class SongTagListViewTestCase(LibraryAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
+        # check that only the conjunction of the two words is found (reverse)
+        response = self.client.get(self.url, {"query": "performance live"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     def test_post_tag_already_exists(self):
         """Test to create a tag when it already exists."""
         # Login as simple user

--- a/dakara_server/library/tests/test_work.py
+++ b/dakara_server/library/tests/test_work.py
@@ -168,6 +168,11 @@ class WorkListViewTestCase(LibraryAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
+        # check that only the conjunction of the two words is found (reverse)
+        response = self.client.get(self.url, {"query": "suzumiya haruhi"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     def test_post_work_simple(self):
         """Test to create a work without embedded data."""
         # pre-assert there are 3 works

--- a/dakara_server/library/tests/test_work.py
+++ b/dakara_server/library/tests/test_work.py
@@ -152,6 +152,22 @@ class WorkListViewTestCase(LibraryAPITestCase):
             ["word", "words words words", "remain"],
         )
 
+    def test_get_works_list_with_query_two_words(self):
+        """Test to search the intersection of two words in the query.
+
+        Related to #192.
+        """
+        work_titles = ["haruhi suzumiya", "haruhi", "suzumiya"]
+        for title in work_titles:
+            Work.objects.create(title=title, work_type=self.wt1)
+
+        self.authenticate(self.user)
+
+        # check that only the conjunction of the two words is found
+        response = self.client.get(self.url, {"query": "haruhi suzumiya"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     def test_post_work_simple(self):
         """Test to create a work without embedded data."""
         # pre-assert there are 3 works

--- a/dakara_server/playlist/query.py
+++ b/dakara_server/playlist/query.py
@@ -43,7 +43,7 @@ def make_entries_query_from_res(res, prefix=None):
         query_list.append(q(prefix, "owner__username__iexact", owner))
 
     # unspecific terms of the research
-    # cunjunction of all terms
+    # conjunction of all terms
     query_remain = Q()
     for remain in res["remaining"]:
         query_remain &= q(prefix, "owner__username__icontains", remain)

--- a/dakara_server/playlist/query.py
+++ b/dakara_server/playlist/query.py
@@ -10,7 +10,7 @@ def make_entries_query_from_res(res, prefix=None):
     """Make a query for playlist entries.
 
     Args:
-        res (dict): Dictionary on research terms, parsed. If `id` is in the
+        res (dict): Dictionary of research terms, parsed. If `id` is in the
             query terms, only filter by it.
         prefix (str or None): Optional prefix to add when creating the query.
 
@@ -43,8 +43,12 @@ def make_entries_query_from_res(res, prefix=None):
         query_list.append(q(prefix, "owner__username__iexact", owner))
 
     # unspecific terms of the research
+    # cunjunction of all terms
+    query_remain = Q()
     for remain in res["remaining"]:
-        query_list_remain.append(q(prefix, "owner__username__icontains", remain))
+        query_remain &= q(prefix, "owner__username__icontains", remain)
+
+    query_list_remain.append(query_remain)
 
     return query_list, query_list_remain, query_list_many
 
@@ -116,8 +120,12 @@ def make_errors_query_from_res(res):
         query_list.append(Q(error_message__iexact=message))
 
     # unspecific terms of the research
+    # conjunction of all terms
+    query_remain = Q()
     for remain in res["remaining"]:
-        query_list_remain.append(Q(error_message__icontains=remain))
+        query_remain &= Q(error_message__icontains=remain)
+
+    query_list_remain.append(query_remain)
 
     return query_list, query_list_remain, query_list_many
 

--- a/dakara_server/playlist/tests/test_player_error.py
+++ b/dakara_server/playlist/tests/test_player_error.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from internal.tests.base_test import tz
-from playlist.models import PlayerError
+from playlist.models import PlayerError, PlaylistEntry
 from playlist.tests.base_test import PlaylistAPITestCase
 
 
@@ -150,6 +150,28 @@ class PlayerErrorListViewTestCase(PlaylistAPITestCase):
         self.authenticate(self.user)
 
         self.check_query("title: song1", [error])
+
+    def test_get_errors_with_query_two_words(self):
+        """Test to search the intersection of two words in the query.
+
+        Related to #192.
+        """
+        error_messages = ["leek overflow", "leek", "overflow"]
+        for message in error_messages:
+            pe = PlaylistEntry.objects.create(
+                song=self.song1,
+                owner=self.manager,
+                was_played=True,
+                date_play=datetime.now(tz),
+            )
+            PlayerError.objects.create(playlist_entry=pe, error_message=message)
+
+        self.authenticate(self.user)
+
+        # check that only the conjunction of the two words is found
+        response = self.client.get(self.url, {"query": "leek overflow"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
 
     @patch("playlist.views.send_to_channel")
     def test_post_error_success(self, mocked_send_to_channel):

--- a/dakara_server/playlist/tests/test_player_error.py
+++ b/dakara_server/playlist/tests/test_player_error.py
@@ -173,6 +173,11 @@ class PlayerErrorListViewTestCase(PlaylistAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
+        # check that only the conjunction of the two words is found (reverse)
+        response = self.client.get(self.url, {"query": "overflow leek"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     @patch("playlist.views.send_to_channel")
     def test_post_error_success(self, mocked_send_to_channel):
         """Test to create an error."""

--- a/dakara_server/playlist/tests/test_playlist_played.py
+++ b/dakara_server/playlist/tests/test_playlist_played.py
@@ -1,6 +1,10 @@
+from datetime import datetime
+
 from django.urls import reverse
 from rest_framework import status
 
+from internal.tests.base_test import UserModel, tz
+from playlist.models import PlaylistEntry
 from playlist.tests.base_test import PlaylistAPITestCase
 
 
@@ -64,3 +68,30 @@ class PlaylistPlayedListViewTestCase(PlaylistAPITestCase):
         self.check_query('owner:"manager"', [self.pe3])
         self.check_query('owner:""testPlaylistManager""', [self.pe3])
         self.check_query("owner:user", [self.pe4])
+
+    def test_get_playlist_played_list_two_words(self):
+        """Test to search the intersection of two words in the query.
+
+        Related to #192.
+        """
+        user_names = ["hatsune miku", "hatsune", "miku"]
+        for name in user_names:
+            user = self.create_user(name, playlist_level=UserModel.USER)
+            PlaylistEntry.objects.create(
+                song=self.song1,
+                owner=user,
+                was_played=True,
+                date_play=datetime.now(tz),
+            )
+
+        self.authenticate(self.user)
+
+        # check that only the conjunction of the two words is found
+        response = self.client.get(self.url, {"query": "hatsune miku"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+        # check that only the conjunction of the two words is found (reverse)
+        response = self.client.get(self.url, {"query": "miku hatsune"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)

--- a/dakara_server/playlist/tests/test_playlist_queuing.py
+++ b/dakara_server/playlist/tests/test_playlist_queuing.py
@@ -97,6 +97,11 @@ class PlaylistQueuingListViewTestCase(PlaylistAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
+        # check that only the conjunction of the two words is found (reverse)
+        response = self.client.get(self.url, {"query": "miku hatsune"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     @patch("playlist.views.send_to_channel")
     def test_post_create_playlist_entry(self, mocked_send_to_channel):
         """Test to verify playlist entry creation."""

--- a/dakara_server/playlist/tests/test_playlist_queuing.py
+++ b/dakara_server/playlist/tests/test_playlist_queuing.py
@@ -77,6 +77,26 @@ class PlaylistQueuingListViewTestCase(PlaylistAPITestCase):
         self.check_query('owner:""testPlaylistManager""', [self.pe1])
         self.check_query("owner: user", [self.pe2])
 
+    def test_get_playlist_queuing_list_two_words(self):
+        """Test to search the intersection of two words in the query.
+
+        Related to #192.
+        """
+        user_names = ["hatsune miku", "hatsune", "miku"]
+        for name in user_names:
+            user = self.create_user(name, playlist_level=UserModel.USER)
+            PlaylistEntry.objects.create(
+                song=self.song1,
+                owner=user,
+            )
+
+        self.authenticate(self.user)
+
+        # check that only the conjunction of the two words is found
+        response = self.client.get(self.url, {"query": "hatsune miku"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     @patch("playlist.views.send_to_channel")
     def test_post_create_playlist_entry(self, mocked_send_to_channel):
         """Test to verify playlist entry creation."""

--- a/dakara_server/users/query.py
+++ b/dakara_server/users/query.py
@@ -8,7 +8,7 @@ def make_users_query_from_res(res):
     """Make a query for users.
 
     Args:
-        res (dict): Dictionary on research terms, parsed. If `id` is in the
+        res (dict): Dictionary of research terms, parsed. If `id` is in the
             query terms, only filter by it.
         prefix (str or None): Optional prefix to add when creating the query.
 
@@ -29,8 +29,12 @@ def make_users_query_from_res(res):
     query_list_remain = []
 
     # only unspecific terms are used
+    # conjunction of all terms
+    query_remain = Q()
     for remain in res["remaining"]:
-        query_list_remain.append(Q(username__icontains=remain))
+        query_remain &= Q(username__icontains=remain)
+
+    query_list_remain.append(query_remain)
 
     return [], query_list_remain
 

--- a/dakara_server/users/tests/test_views.py
+++ b/dakara_server/users/tests/test_views.py
@@ -273,6 +273,11 @@ class UserListViewTestCase(UsersAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
+        # check that only the conjunction of the two words is found (reverse)
+        response = self.client.get(self.url, {"query": "miku hatsune"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     @patch("users.views.send_register_verification_email_notification")
     def test_create_user(self, mocked_send_email):
         """Test to verify user creation."""

--- a/dakara_server/users/tests/test_views.py
+++ b/dakara_server/users/tests/test_views.py
@@ -257,6 +257,22 @@ class UserListViewTestCase(UsersAPITestCase):
 
         self.check_query("id:1", [self.user])
 
+    def test_get_users_list_two_words(self):
+        """Test to search the intersection of two words in the query.
+
+        Related to #192.
+        """
+        user_names = ["hatsune miku", "hatsune", "miku"]
+        for name in user_names:
+            self.create_user(name, playlist_level=UserModel.USER)
+
+        self.authenticate(self.user)
+
+        # check that only the conjunction of the two words is found
+        response = self.client.get(self.url, {"query": "hatsune miku"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
     @patch("users.views.send_register_verification_email_notification")
     def test_create_user(self, mocked_send_email):
         """Test to verify user creation."""


### PR DESCRIPTION
#181 introduced the possibility to search more than songs, and was a refactor of the search engine. The implementation prior the PR allowed to find the conjunction of remaining terms (i.e., without using the mini-language keywords), when the implementation after it finds the disjunction of these terms. This behavior was not tested.

This PR reestablishes the conjunction of remaining terms for all type of queries:

- Songs;
- Artists;
- Song tags;
- Works;
- Playlist entries;
- Player errors; and
- Users.